### PR TITLE
Change swipes list icon to font awesome

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,11 +413,11 @@ const addSwipesButtons = ()=>{
 };
 const addSwipesButton = (mesIdx, isForced = false)=>{
     const container = document.querySelector(`#chat > .mes[mesid="${mesIdx}"] .extraMesButtons`);
-    if (!isForced && container.querySelector('.mfc--button')) return;
-    Array.from(container.querySelectorAll('.mfc--button')).forEach(it=>it.remove());
+    if (!isForced && container.querySelector('.mfc--swipes')) return;
+    Array.from(container.querySelectorAll('.mfc--swipes')).forEach(it=>it.remove());
     const mes = chat[mesIdx];
     const btn = document.createElement('div'); {
-        btn.classList.add('mfc--button', 'mfc--mes_swipes', 'fa-solid', 'fa-layer-group');
+        btn.classList.add('mfc--swipes', 'fa-solid', 'fa-layer-group');
         btn.title = `View swipes (${mes.swipes?.length ?? 0})`;
         btn.addEventListener('click', async(evt)=>{
             const dom = document.createElement('div'); {

--- a/index.js
+++ b/index.js
@@ -417,8 +417,7 @@ const addSwipesButton = (mesIdx, isForced = false)=>{
     Array.from(container.querySelectorAll('.mfc--button')).forEach(it=>it.remove());
     const mes = chat[mesIdx];
     const btn = document.createElement('div'); {
-        btn.classList.add('mfc--button');
-        btn.textContent = '▤';
+        $(btn).addClass('mfc--button mes_swipes fa-solid fa-arrows-left-right-to-line');
         btn.title = `View swipes (${mes.swipes?.length ?? 0})`;
         btn.addEventListener('click', async(evt)=>{
             const dom = document.createElement('div'); {

--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ const addSwipesButton = (mesIdx, isForced = false)=>{
     Array.from(container.querySelectorAll('.mfc--button')).forEach(it=>it.remove());
     const mes = chat[mesIdx];
     const btn = document.createElement('div'); {
-        $(btn).addClass('mfc--button mes_swipes fa-solid fa-arrows-left-right-to-line');
+        btn.classList.add('mfc--button', 'mes_swipes', 'fa-solid', 'fa-arrows-left-right-to-line');
         btn.title = `View swipes (${mes.swipes?.length ?? 0})`;
         btn.addEventListener('click', async(evt)=>{
             const dom = document.createElement('div'); {

--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ const addSwipesButton = (mesIdx, isForced = false)=>{
     Array.from(container.querySelectorAll('.mfc--button')).forEach(it=>it.remove());
     const mes = chat[mesIdx];
     const btn = document.createElement('div'); {
-        btn.classList.add('mfc--button', 'mes_swipes', 'fa-solid', 'fa-arrows-left-right-to-line');
+        btn.classList.add('mfc--button', 'mfc--mes_swipes', 'fa-solid', 'fa-layer-group');
         btn.title = `View swipes (${mes.swipes?.length ?? 0})`;
         btn.addEventListener('click', async(evt)=>{
             const dom = document.createElement('div'); {


### PR DESCRIPTION
Changed the icon for the "view swipes" on the three-dots right menu to a font awesome icon that matches the style and size of all the others.

![image](https://github.com/LenAnderson/SillyTavern-MoreFlexibleContinues/assets/9962104/1cb73d50-b7ff-4ac9-9b06-e07488fc4c8f)

If you don't think that icon matches the spirit of the intention, there are other fa icons we could choose. I thought the arrows work though, as swipes are usually represented by arrows.  
Any of those I could see to work too:
![image](https://github.com/LenAnderson/SillyTavern-MoreFlexibleContinues/assets/9962104/c2cb88de-b1fa-461c-b831-c01f17a1e9bb)
